### PR TITLE
Do not use the Access protocol as it has been deprecated.

### DIFF
--- a/lib/countries.ex
+++ b/lib/countries.ex
@@ -19,7 +19,7 @@ defmodule Countries do
   def filter_by(attribute, value) do
     Enum.filter(countries, fn(country) ->
       value_as_char_list = to_char_list(value)
-      country[attribute] == value_as_char_list
+      Map.get(country, attribute) == value_as_char_list
     end)
   end
   

--- a/lib/country.ex
+++ b/lib/country.ex
@@ -1,5 +1,4 @@
 defmodule Countries.Country do
-  @derive [Access]
   defstruct [:number, :alpha2, :alpha3, :currency, :name, :names, 
             :latitude, :longitude, :continent, :region, :subregion, 
             :world_region, :country_code, :national_destination_code_lengths, 


### PR DESCRIPTION
I removed the use of the Access protocol, as it has been removed in Elixir 1.1. (see this discussion: https://github.com/elixir-lang/elixir/issues/2973).

I only needed to change one use of the `[]` syntax to pass the tests.

Closes #4 