### PR TITLE
Fix compilation errors

### DIFF
--- a/lib/country.ex
+++ b/lib/country.ex
@@ -1,10 +1,9 @@
 defmodule Countries.Country do
-  defstruct [:number, :alpha2, :alpha3, :currency, :name, :names,
-            :latitude, :longitude, :continent, :region, :subregion,
+  defstruct [:number, :alpha2, :alpha3, :currency, :name, :unofficial_names,
+            :continent, :region, :subregion, :geo,
             :world_region, :country_code, :national_destination_code_lengths,
             :national_number_lengths, :international_prefix, :national_prefix,
-            :address_format, :ioc, :gec, :un_locode, :languages, :nationality,
+            :ioc, :gec, :un_locode, :languages_official, :languages_spoken, :nationality,
             :address_format, :dissolved_on, :eu_member, :alt_currency, :vat_rates,
-            :postal_code, :min_longitude, :min_latitude, :max_longitude, :max_latitude,
-            :latitude_dec, :longitude_dec]
+            :postal_code, :currency_code]
 end

--- a/lib/loader.ex
+++ b/lib/loader.ex
@@ -1,6 +1,7 @@
 defmodule Countries.Loader do
   @moduledoc false
 
+  import Countries.Utils, only: [to_map: 1]
   alias Countries.Country
 
   @data_path Path.expand("data", __DIR__)
@@ -44,8 +45,11 @@ defmodule Countries.Loader do
     end)
   end
 
-  defp convert_value(:names, names),
+  defp convert_value(:unofficial_names, names),
     do: Enum.map(names, &to_string/1)
+
+  defp convert_value(:geo, values),
+    do: to_map(values)
 
   defp convert_value(attribute, value)
     when is_list(value) and not attribute in @do_not_convert,
@@ -53,5 +57,4 @@ defmodule Countries.Loader do
 
   defp convert_value(_, value),
     do: value
-
 end

--- a/lib/subdivision.ex
+++ b/lib/subdivision.ex
@@ -1,0 +1,3 @@
+defmodule Countries.Subdivision do
+  defstruct [:id, :name, :unofficial_names, :translations, :geo]
+end

--- a/lib/subdivisions.ex
+++ b/lib/subdivisions.ex
@@ -1,8 +1,38 @@
 defmodule Countries.Subdivisions do
+  import Countries.Utils, only: [to_map: 1]
+  alias Countries.Subdivision
 
   def all(country) do
-    subdivisions(country.alpha2)
+    country.alpha2
+    |> subdivisions()
+    |> Enum.map(&convert_subdivision/1)
   end
+
+  defp convert_subdivision({id, attrs}) do
+     Enum.reduce(attrs, %Subdivision{id: id}, fn({attribute, value}, subdivision) ->
+       with attribute = List.to_atom(attribute) do
+         Map.put(subdivision, attribute, convert_value(attribute, value))
+       end
+     end)
+  end
+
+  defp convert_value(_, :null),
+    do: nil
+
+  defp convert_value(:unofficial_names, names),
+    do: Enum.map(names, &to_string/1)
+
+  defp convert_value(:translations, names),
+    do: to_map(names)
+
+  defp convert_value(:geo, values),
+    do: to_map(values)
+
+  defp convert_value(_, value) when is_list(value),
+    do: to_string(value)
+
+  defp convert_value(_, value),
+    do: value
 
   # Ensure :yamerl is running
   Application.start(:yamerl)

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,0 +1,8 @@
+defmodule Countries.Utils do
+  def to_map([item | _] = values) when is_tuple(item),
+    do: Enum.reduce(values, Map.new, fn ({key, value}, acc) ->
+      Map.put(acc, key |> to_string() |> String.to_atom(), to_map(value))
+    end)
+  def to_map(value) when is_list(value), do: to_string(value)
+  def to_map(value), do: value
+end

--- a/test/countries_test.exs
+++ b/test/countries_test.exs
@@ -7,15 +7,15 @@ defmodule CountriesTest do
   end
 
   test "filter countries by name" do
-    countries = Countries.filter_by(:name, "United Kingdom")
+    countries = Countries.filter_by(:name, "United Kingdom of Great Britain and Northern Ireland")
     assert Enum.count(countries) == 1
   end
 
   test "filter countries by alternative names" do
-    countries = Countries.filter_by(:names, "Reino Unido")
+    countries = Countries.filter_by(:unofficial_names, "Reino Unido")
     assert Enum.count(countries) == 1
 
-    countries = Countries.filter_by(:names, "The United Kingdom")
+    countries = Countries.filter_by(:unofficial_names, "The United Kingdom")
     assert Enum.count(countries) == 1
   end
 


### PR DESCRIPTION
Hello,
This set of modifications should:
- Fix compilation errors that are occuring due to a change in the structure of the data (e.g. addition of `geo` field)
- Add `Countries.Subdivision` struct as traversing the nested tuples for the subdivisions is inconvenient. 