### PR TITLE
Add emoji_flag property for all countries

### DIFF
--- a/lib/country.ex
+++ b/lib/country.ex
@@ -1,6 +1,6 @@
 defmodule Countries.Country do
   defstruct [:number, :alpha2, :alpha3, :currency, :name, :unofficial_names,
-            :continent, :region, :subregion, :geo,
+            :continent, :region, :subregion, :geo, :emoji_flag,
             :world_region, :country_code, :national_destination_code_lengths,
             :national_number_lengths, :international_prefix, :national_prefix,
             :ioc, :gec, :un_locode, :languages_official, :languages_spoken, :nationality,

--- a/lib/data/countries/AD.yaml
+++ b/lib/data/countries/AD.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: AD
 alpha3: AND
 country_code: '376'
+emoji_flag: 🇦🇩
 international_prefix: '00'
 ioc: AND
 gec: AN

--- a/lib/data/countries/AE.yaml
+++ b/lib/data/countries/AE.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: AE
 alpha3: ARE
 country_code: '971'
+emoji_flag: 🇦🇪
 international_prefix: '00'
 ioc: UAE
 gec: AE

--- a/lib/data/countries/AF.yaml
+++ b/lib/data/countries/AF.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: AF
 alpha3: AFG
 country_code: '93'
+emoji_flag: 🇦🇫
 international_prefix: '00'
 ioc: AFG
 gec: AF

--- a/lib/data/countries/AG.yaml
+++ b/lib/data/countries/AG.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: AG
 alpha3: ATG
 country_code: '1'
+emoji_flag: 🇦🇬
 nanp_prefix: '1268'
 international_prefix: '011'
 ioc: ANT

--- a/lib/data/countries/AI.yaml
+++ b/lib/data/countries/AI.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: AI
 alpha3: AIA
 country_code: '1'
+emoji_flag: 🇦🇮
 nanp_prefix: '1264'
 international_prefix: '011'
 ioc:

--- a/lib/data/countries/AL.yaml
+++ b/lib/data/countries/AL.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: AL
 alpha3: ALB
 country_code: '355'
+emoji_flag: 🇦🇱
 international_prefix: '00'
 ioc: ALB
 gec: AL

--- a/lib/data/countries/AM.yaml
+++ b/lib/data/countries/AM.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: AM
 alpha3: ARM
 country_code: '374'
+emoji_flag: 🇦🇲
 international_prefix: '00'
 ioc: ARM
 gec: AM

--- a/lib/data/countries/AN.yaml
+++ b/lib/data/countries/AN.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: AN
 alpha3: ANT
 country_code: '599'
+emoji_flag: 🏳️
 currency: ANG
 international_prefix: '00'
 ioc: AHO

--- a/lib/data/countries/AO.yaml
+++ b/lib/data/countries/AO.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: AO
 alpha3: AGO
 country_code: '244'
+emoji_flag: 🇦🇴
 international_prefix: '00'
 ioc: ANG
 gec: AO

--- a/lib/data/countries/AQ.yaml
+++ b/lib/data/countries/AQ.yaml
@@ -3,6 +3,7 @@ continent: Antarctica
 alpha2: AQ
 alpha3: ATA
 country_code: '672'
+emoji_flag: 🇦🇶
 international_prefix: ''
 ioc:
 gec: AY

--- a/lib/data/countries/AR.yaml
+++ b/lib/data/countries/AR.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: AR
 alpha3: ARG
 country_code: '54'
+emoji_flag: 🇦🇷
 international_prefix: '00'
 ioc: ARG
 gec: AR

--- a/lib/data/countries/AS.yaml
+++ b/lib/data/countries/AS.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: AS
 alpha3: ASM
 country_code: '1'
+emoji_flag: 🇦🇸
 nanp_prefix: '1684'
 international_prefix: '011'
 ioc: ASA

--- a/lib/data/countries/AT.yaml
+++ b/lib/data/countries/AT.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: AT
 alpha3: AUT
 country_code: '43'
+emoji_flag: 🇦🇹
 international_prefix: '00'
 ioc: AUT
 gec: AU

--- a/lib/data/countries/AU.yaml
+++ b/lib/data/countries/AU.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: AU
 alpha3: AUS
 country_code: '61'
+emoji_flag: 🇦🇺
 international_prefix: '0011'
 ioc: AUS
 gec: AS

--- a/lib/data/countries/AW.yaml
+++ b/lib/data/countries/AW.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: AW
 alpha3: ABW
 country_code: '297'
+emoji_flag: 🇦🇼
 international_prefix: '00'
 ioc: ARU
 gec: AA

--- a/lib/data/countries/AX.yaml
+++ b/lib/data/countries/AX.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: AX
 alpha3: ALA
 country_code: '358'
+emoji_flag: 🇦🇽
 international_prefix: ''
 ioc:
 gec:

--- a/lib/data/countries/AZ.yaml
+++ b/lib/data/countries/AZ.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: AZ
 alpha3: AZE
 country_code: '994'
+emoji_flag: 🇦🇿
 international_prefix: '810'
 ioc: AZE
 gec: AJ

--- a/lib/data/countries/BA.yaml
+++ b/lib/data/countries/BA.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: BA
 alpha3: BIH
 country_code: '387'
+emoji_flag: 🇧🇦
 international_prefix: '00'
 ioc: BIH
 gec: BK

--- a/lib/data/countries/BB.yaml
+++ b/lib/data/countries/BB.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: BB
 alpha3: BRB
 country_code: '1'
+emoji_flag: 🇧🇧
 nanp_prefix: '1246'
 international_prefix: '011'
 ioc: BAR

--- a/lib/data/countries/BD.yaml
+++ b/lib/data/countries/BD.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: BD
 alpha3: BGD
 country_code: '880'
+emoji_flag: 🇧🇩
 international_prefix: '00'
 ioc: BAN
 gec: BG

--- a/lib/data/countries/BE.yaml
+++ b/lib/data/countries/BE.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: BE
 alpha3: BEL
 country_code: '32'
+emoji_flag: 🇧🇪
 international_prefix: '00'
 ioc: BEL
 gec: BE

--- a/lib/data/countries/BF.yaml
+++ b/lib/data/countries/BF.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: BF
 alpha3: BFA
 country_code: '226'
+emoji_flag: 🇧🇫
 international_prefix: '00'
 ioc: BUR
 gec: UV

--- a/lib/data/countries/BG.yaml
+++ b/lib/data/countries/BG.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: BG
 alpha3: BGR
 country_code: '359'
+emoji_flag: 🇧🇬
 international_prefix: '00'
 ioc: BUL
 gec: BU

--- a/lib/data/countries/BH.yaml
+++ b/lib/data/countries/BH.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: BH
 alpha3: BHR
 country_code: '973'
+emoji_flag: 🇧🇭
 international_prefix: '00'
 ioc: BRN
 gec: BA

--- a/lib/data/countries/BI.yaml
+++ b/lib/data/countries/BI.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: BI
 alpha3: BDI
 country_code: '257'
+emoji_flag: 🇧🇮
 international_prefix: '00'
 ioc: BDI
 gec: BY

--- a/lib/data/countries/BJ.yaml
+++ b/lib/data/countries/BJ.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: BJ
 alpha3: BEN
 country_code: '229'
+emoji_flag: 🇧🇯
 international_prefix: '00'
 ioc: BEN
 gec: BN

--- a/lib/data/countries/BL.yaml
+++ b/lib/data/countries/BL.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: BL
 alpha3: BLM
 country_code: '590'
+emoji_flag: 🇧🇱
 international_prefix: ''
 ioc:
 gec: TB

--- a/lib/data/countries/BM.yaml
+++ b/lib/data/countries/BM.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: BM
 alpha3: BMU
 country_code: '1'
+emoji_flag: 🇧🇲
 nanp_prefix: '1441'
 international_prefix: '011'
 ioc: BER

--- a/lib/data/countries/BN.yaml
+++ b/lib/data/countries/BN.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: BN
 alpha3: BRN
 country_code: '673'
+emoji_flag: 🇧🇳
 international_prefix: '00'
 ioc: BRU
 gec: BX

--- a/lib/data/countries/BO.yaml
+++ b/lib/data/countries/BO.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: BO
 alpha3: BOL
 country_code: '591'
+emoji_flag: 🇧🇴
 international_prefix: '0010'
 ioc: BOL
 gec: BL

--- a/lib/data/countries/BQ.yaml
+++ b/lib/data/countries/BQ.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: BQ
 alpha3: BES
 country_code: '599'
+emoji_flag: 🇧🇶
 international_prefix: '00'
 name: Bonaire, Sint Eustatius and Saba
 national_destination_code_lengths:

--- a/lib/data/countries/BR.yaml
+++ b/lib/data/countries/BR.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: BR
 alpha3: BRA
 country_code: '55'
+emoji_flag: 🇧🇷
 international_prefix: '0014'
 ioc: BRA
 gec: BR

--- a/lib/data/countries/BS.yaml
+++ b/lib/data/countries/BS.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: BS
 alpha3: BHS
 country_code: '1'
+emoji_flag: 🇧🇸
 nanp_prefix: '1242'
 international_prefix: '011'
 ioc: BAH

--- a/lib/data/countries/BT.yaml
+++ b/lib/data/countries/BT.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: BT
 alpha3: BTN
 country_code: '975'
+emoji_flag: 🇧🇹
 international_prefix: '00'
 ioc: BHU
 gec: BT

--- a/lib/data/countries/BV.yaml
+++ b/lib/data/countries/BV.yaml
@@ -3,6 +3,7 @@ continent: Antarctica
 alpha2: BV
 alpha3: BVT
 country_code: '47'
+emoji_flag: 🇧🇻
 international_prefix: ''
 ioc:
 gec: BV

--- a/lib/data/countries/BW.yaml
+++ b/lib/data/countries/BW.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: BW
 alpha3: BWA
 country_code: '267'
+emoji_flag: 🇧🇼
 international_prefix: '00'
 ioc: BOT
 gec: BC

--- a/lib/data/countries/BY.yaml
+++ b/lib/data/countries/BY.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: BY
 alpha3: BLR
 country_code: '375'
+emoji_flag: 🇧🇾
 international_prefix: '810'
 ioc: BLR
 gec: BO

--- a/lib/data/countries/BZ.yaml
+++ b/lib/data/countries/BZ.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: BZ
 alpha3: BLZ
 country_code: '501'
+emoji_flag: 🇧🇿
 international_prefix: '00'
 ioc: BIZ
 gec: BH

--- a/lib/data/countries/CA.yaml
+++ b/lib/data/countries/CA.yaml
@@ -7,6 +7,7 @@ address_format: |-
   {{country}}
 alpha2: CA
 alpha3: CAN
+emoji_flag: 🇨🇦
 country_code: '1'
 international_prefix: '011'
 ioc: CAN

--- a/lib/data/countries/CC.yaml
+++ b/lib/data/countries/CC.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: CC
 alpha3: CCK
 country_code: '61'
+emoji_flag: 🇨🇨
 international_prefix: '0011'
 ioc:
 gec: CK

--- a/lib/data/countries/CD.yaml
+++ b/lib/data/countries/CD.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: CD
 alpha3: COD
 country_code: '243'
+emoji_flag: 🇨🇩
 international_prefix: '00'
 ioc: COD
 gec: CG

--- a/lib/data/countries/CF.yaml
+++ b/lib/data/countries/CF.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: CF
 alpha3: CAF
 country_code: '236'
+emoji_flag: 🇨🇫
 international_prefix: '00'
 ioc: CAF
 gec: CT

--- a/lib/data/countries/CG.yaml
+++ b/lib/data/countries/CG.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: CG
 alpha3: COG
 country_code: '242'
+emoji_flag: 🇨🇬
 international_prefix: '00'
 ioc: CGO
 gec: CF

--- a/lib/data/countries/CH.yaml
+++ b/lib/data/countries/CH.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: CH
 alpha3: CHE
 country_code: '41'
+emoji_flag: 🇨🇭
 international_prefix: '00'
 ioc: SUI
 gec: SZ

--- a/lib/data/countries/CI.yaml
+++ b/lib/data/countries/CI.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: CI
 alpha3: CIV
 country_code: '225'
+emoji_flag: 🇨🇮
 international_prefix: '00'
 ioc: CIV
 gec: IV

--- a/lib/data/countries/CK.yaml
+++ b/lib/data/countries/CK.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: CK
 alpha3: COK
 country_code: '682'
+emoji_flag: 🇨🇰
 international_prefix: '00'
 ioc: COK
 gec: CW

--- a/lib/data/countries/CL.yaml
+++ b/lib/data/countries/CL.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: CL
 alpha3: CHL
 country_code: '56'
+emoji_flag: 🇨🇱
 international_prefix: '00'
 ioc: CHI
 gec: CI

--- a/lib/data/countries/CM.yaml
+++ b/lib/data/countries/CM.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: CM
 alpha3: CMR
 country_code: '237'
+emoji_flag: 🇨🇲
 international_prefix: '00'
 ioc: CMR
 gec: CM

--- a/lib/data/countries/CN.yaml
+++ b/lib/data/countries/CN.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: CN
 alpha3: CHN
 country_code: '86'
+emoji_flag: 🇨🇳
 international_prefix: '00'
 ioc: CHN
 gec: CH

--- a/lib/data/countries/CO.yaml
+++ b/lib/data/countries/CO.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: CO
 alpha3: COL
 country_code: '57'
+emoji_flag: 🇨🇴
 international_prefix: '005'
 ioc: COL
 gec: CO

--- a/lib/data/countries/CR.yaml
+++ b/lib/data/countries/CR.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: CR
 alpha3: CRI
 country_code: '506'
+emoji_flag: 🇨🇷
 international_prefix: '00'
 ioc: CRC
 gec: CS

--- a/lib/data/countries/CU.yaml
+++ b/lib/data/countries/CU.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: CU
 alpha3: CUB
 country_code: '53'
+emoji_flag: 🇨🇺
 international_prefix: '119'
 ioc: CUB
 gec: CU

--- a/lib/data/countries/CV.yaml
+++ b/lib/data/countries/CV.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: CV
 alpha3: CPV
 country_code: '238'
+emoji_flag: 🇨🇻
 international_prefix: '00'
 ioc: CPV
 gec: CV

--- a/lib/data/countries/CW.yaml
+++ b/lib/data/countries/CW.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: CW
 alpha3: CUW
 country_code: '599'
+emoji_flag: 🇨🇼
 international_prefix: '00'
 ioc:
 gec: UC

--- a/lib/data/countries/CX.yaml
+++ b/lib/data/countries/CX.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: CX
 alpha3: CXR
 country_code: '61'
+emoji_flag: 🇨🇽
 international_prefix: '0011'
 ioc:
 gec: KT

--- a/lib/data/countries/CY.yaml
+++ b/lib/data/countries/CY.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: CY
 alpha3: CYP
 country_code: '357'
+emoji_flag: 🇨🇾
 international_prefix: '00'
 ioc: CYP
 gec: CY

--- a/lib/data/countries/CZ.yaml
+++ b/lib/data/countries/CZ.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: CZ
 alpha3: CZE
 country_code: '420'
+emoji_flag: 🇨🇿
 international_prefix: '00'
 ioc: CZE
 gec: EZ

--- a/lib/data/countries/DE.yaml
+++ b/lib/data/countries/DE.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: DE
 alpha3: DEU
 country_code: '49'
+emoji_flag: 🇩🇪
 international_prefix: '00'
 ioc: GER
 gec: GM

--- a/lib/data/countries/DJ.yaml
+++ b/lib/data/countries/DJ.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: DJ
 alpha3: DJI
 country_code: '253'
+emoji_flag: 🇩🇯
 international_prefix: '00'
 ioc: DJI
 gec: DJ

--- a/lib/data/countries/DK.yaml
+++ b/lib/data/countries/DK.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: DK
 alpha3: DNK
 country_code: '45'
+emoji_flag: 🇩🇰
 international_prefix: '00'
 ioc: DEN
 gec: DA

--- a/lib/data/countries/DM.yaml
+++ b/lib/data/countries/DM.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: DM
 alpha3: DMA
 country_code: '1'
+emoji_flag: 🇩🇲
 nanp_prefix: '1767'
 international_prefix: '011'
 ioc: DMA

--- a/lib/data/countries/DO.yaml
+++ b/lib/data/countries/DO.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: DO
 alpha3: DOM
 country_code: '1'
+emoji_flag: 🇩🇴
 international_prefix: '011'
 ioc: DOM
 gec: DR

--- a/lib/data/countries/DZ.yaml
+++ b/lib/data/countries/DZ.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: DZ
 alpha3: DZA
 country_code: '213'
+emoji_flag: 🇩🇿
 international_prefix: '00'
 ioc: ALG
 gec: AG

--- a/lib/data/countries/EC.yaml
+++ b/lib/data/countries/EC.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: EC
 alpha3: ECU
 country_code: '593'
+emoji_flag: 🇪🇨
 international_prefix: '00'
 ioc: ECU
 gec: EC

--- a/lib/data/countries/EE.yaml
+++ b/lib/data/countries/EE.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: EE
 alpha3: EST
 country_code: '372'
+emoji_flag: 🇪🇪
 international_prefix: '00'
 ioc: EST
 gec: EN

--- a/lib/data/countries/EG.yaml
+++ b/lib/data/countries/EG.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: EG
 alpha3: EGY
 country_code: '20'
+emoji_flag: 🇪🇬
 international_prefix: '00'
 ioc: EGY
 gec: EG

--- a/lib/data/countries/EH.yaml
+++ b/lib/data/countries/EH.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: EH
 alpha3: ESH
 country_code: '212'
+emoji_flag: 🇪🇭
 international_prefix: ''
 ioc:
 gec: WI

--- a/lib/data/countries/ER.yaml
+++ b/lib/data/countries/ER.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: ER
 alpha3: ERI
 country_code: '291'
+emoji_flag: 🇪🇷
 international_prefix: '00'
 ioc: ERI
 gec: ER

--- a/lib/data/countries/ES.yaml
+++ b/lib/data/countries/ES.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: ES
 alpha3: ESP
 country_code: '34'
+emoji_flag: 🇪🇸
 international_prefix: '00'
 ioc: ESP
 gec: SP

--- a/lib/data/countries/ET.yaml
+++ b/lib/data/countries/ET.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: ET
 alpha3: ETH
 country_code: '251'
+emoji_flag: 🇪🇹
 international_prefix: '00'
 ioc: ETH
 gec: ET

--- a/lib/data/countries/FI.yaml
+++ b/lib/data/countries/FI.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: FI
 alpha3: FIN
 country_code: '358'
+emoji_flag: 🇫🇮
 international_prefix: '00'
 ioc: FIN
 gec: FI

--- a/lib/data/countries/FJ.yaml
+++ b/lib/data/countries/FJ.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: FJ
 alpha3: FJI
 country_code: '679'
+emoji_flag: 🇫🇯
 international_prefix: '00'
 ioc: FIJ
 gec: FJ

--- a/lib/data/countries/FK.yaml
+++ b/lib/data/countries/FK.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: FK
 alpha3: FLK
 country_code: '500'
+emoji_flag: 🇫🇰
 international_prefix: '00'
 ioc:
 gec: FK

--- a/lib/data/countries/FM.yaml
+++ b/lib/data/countries/FM.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: FM
 alpha3: FSM
 country_code: '691'
+emoji_flag: 🇫🇲
 international_prefix: '011'
 ioc: FSM
 gec: FM

--- a/lib/data/countries/FO.yaml
+++ b/lib/data/countries/FO.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: FO
 alpha3: FRO
 country_code: '298'
+emoji_flag: 🇫🇴
 international_prefix: '00'
 ioc: FRO
 gec: FO

--- a/lib/data/countries/FR.yaml
+++ b/lib/data/countries/FR.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: FR
 alpha3: FRA
 country_code: '33'
+emoji_flag: 🇫🇷
 international_prefix: '00'
 ioc: FRA
 gec: FR

--- a/lib/data/countries/GA.yaml
+++ b/lib/data/countries/GA.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: GA
 alpha3: GAB
 country_code: '241'
+emoji_flag: 🇬🇦
 international_prefix: '00'
 ioc: GAB
 gec: GB

--- a/lib/data/countries/GB.yaml
+++ b/lib/data/countries/GB.yaml
@@ -10,6 +10,7 @@ address_format: |-
 alpha2: GB
 alpha3: GBR
 country_code: '44'
+emoji_flag: 🇬🇧
 international_prefix: '00'
 ioc: GBR
 gec: UK

--- a/lib/data/countries/GD.yaml
+++ b/lib/data/countries/GD.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: GD
 alpha3: GRD
 country_code: '1'
+emoji_flag: 🇬🇩
 nanp_prefix: '1473'
 international_prefix: '011'
 ioc: GRN

--- a/lib/data/countries/GE.yaml
+++ b/lib/data/countries/GE.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: GE
 alpha3: GEO
 country_code: '995'
+emoji_flag: 🇬🇪
 international_prefix: '810'
 ioc: GEO
 gec: GG

--- a/lib/data/countries/GF.yaml
+++ b/lib/data/countries/GF.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: GF
 alpha3: GUF
 country_code: '594'
+emoji_flag: 🇬🇫
 international_prefix: '00'
 ioc:
 gec: FG

--- a/lib/data/countries/GG.yaml
+++ b/lib/data/countries/GG.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: GG
 alpha3: GGY
 country_code: '44'
+emoji_flag: 🇬🇬
 international_prefix: ''
 ioc:
 gec: GK

--- a/lib/data/countries/GH.yaml
+++ b/lib/data/countries/GH.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: GH
 alpha3: GHA
 country_code: '233'
+emoji_flag: 🇬🇭
 international_prefix: '00'
 ioc: GHA
 gec: GH

--- a/lib/data/countries/GI.yaml
+++ b/lib/data/countries/GI.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: GI
 alpha3: GIB
 country_code: '350'
+emoji_flag: 🇬🇮
 international_prefix: '00'
 ioc:
 gec: GI

--- a/lib/data/countries/GL.yaml
+++ b/lib/data/countries/GL.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: GL
 alpha3: GRL
 country_code: '299'
+emoji_flag: 🇬🇱
 international_prefix: 009
 ioc:
 gec: GL

--- a/lib/data/countries/GM.yaml
+++ b/lib/data/countries/GM.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: GM
 alpha3: GMB
 country_code: '220'
+emoji_flag: 🇬🇲
 international_prefix: '00'
 ioc: GAM
 gec: GA

--- a/lib/data/countries/GN.yaml
+++ b/lib/data/countries/GN.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: GN
 alpha3: GIN
 country_code: '224'
+emoji_flag: 🇬🇳
 international_prefix: '00'
 ioc: GUI
 gec: GV

--- a/lib/data/countries/GP.yaml
+++ b/lib/data/countries/GP.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: GP
 alpha3: GLP
 country_code: '590'
+emoji_flag: 🇬🇵
 international_prefix: '00'
 ioc:
 gec: GP

--- a/lib/data/countries/GQ.yaml
+++ b/lib/data/countries/GQ.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: GQ
 alpha3: GNQ
 country_code: '240'
+emoji_flag: 🇬🇶
 international_prefix: '00'
 ioc: GEQ
 gec: EK

--- a/lib/data/countries/GR.yaml
+++ b/lib/data/countries/GR.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: GR
 alpha3: GRC
 country_code: '30'
+emoji_flag: 🇬🇷
 international_prefix: '00'
 ioc: GRE
 gec: GR

--- a/lib/data/countries/GS.yaml
+++ b/lib/data/countries/GS.yaml
@@ -3,6 +3,7 @@ continent: Antarctica
 alpha2: GS
 alpha3: SGS
 country_code: '500'
+emoji_flag: 🇬🇸
 international_prefix: ''
 ioc:
 gec: SX

--- a/lib/data/countries/GT.yaml
+++ b/lib/data/countries/GT.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: GT
 alpha3: GTM
 country_code: '502'
+emoji_flag: 🇬🇹
 international_prefix: '00'
 ioc: GUA
 gec: GT

--- a/lib/data/countries/GU.yaml
+++ b/lib/data/countries/GU.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: GU
 alpha3: GUM
 country_code: '1'
+emoji_flag: 🇬🇺
 nanp_prefix: '1671'
 international_prefix: '011'
 ioc: GUM

--- a/lib/data/countries/GW.yaml
+++ b/lib/data/countries/GW.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: GW
 alpha3: GNB
 country_code: '245'
+emoji_flag: 🇬🇼
 international_prefix: '00'
 ioc: GBS
 gec: PU

--- a/lib/data/countries/GY.yaml
+++ b/lib/data/countries/GY.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: GY
 alpha3: GUY
 country_code: '592'
+emoji_flag: 🇬🇾
 international_prefix: '00'
 ioc: GUY
 gec: GY

--- a/lib/data/countries/HK.yaml
+++ b/lib/data/countries/HK.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: HK
 alpha3: HKG
 country_code: '852'
+emoji_flag: 🇭🇰
 international_prefix: '001'
 ioc: HKG
 gec: HK

--- a/lib/data/countries/HM.yaml
+++ b/lib/data/countries/HM.yaml
@@ -3,6 +3,7 @@ continent: Antarctica
 alpha2: HM
 alpha3: HMD
 country_code: ''
+emoji_flag: 🇭🇲
 international_prefix: ''
 ioc:
 gec: HM

--- a/lib/data/countries/HN.yaml
+++ b/lib/data/countries/HN.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: HN
 alpha3: HND
 country_code: '504'
+emoji_flag: 🇭🇳
 international_prefix: '00'
 ioc: HON
 gec: HO

--- a/lib/data/countries/HR.yaml
+++ b/lib/data/countries/HR.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: HR
 alpha3: HRV
 country_code: '385'
+emoji_flag: 🇭🇷
 international_prefix: '00'
 ioc: CRO
 gec: HR

--- a/lib/data/countries/HT.yaml
+++ b/lib/data/countries/HT.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: HT
 alpha3: HTI
 country_code: '509'
+emoji_flag: 🇭🇹
 international_prefix: '00'
 ioc: HAI
 gec: HA

--- a/lib/data/countries/HU.yaml
+++ b/lib/data/countries/HU.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: HU
 alpha3: HUN
 country_code: '36'
+emoji_flag: 🇭🇺
 international_prefix: '00'
 ioc: HUN
 gec: HU

--- a/lib/data/countries/ID.yaml
+++ b/lib/data/countries/ID.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: ID
 alpha3: IDN
 country_code: '62'
+emoji_flag: 🇮🇩
 international_prefix: '001'
 ioc: INA
 gec: ID

--- a/lib/data/countries/IE.yaml
+++ b/lib/data/countries/IE.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: IE
 alpha3: IRL
 country_code: '353'
+emoji_flag: 🇮🇪
 international_prefix: '00'
 ioc: IRL
 gec: EI

--- a/lib/data/countries/IL.yaml
+++ b/lib/data/countries/IL.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: IL
 alpha3: ISR
 country_code: '972'
+emoji_flag: 🇮🇱
 international_prefix: '00'
 ioc: ISR
 gec: IS

--- a/lib/data/countries/IM.yaml
+++ b/lib/data/countries/IM.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: IM
 alpha3: IMN
 country_code: '44'
+emoji_flag: 🇮🇲
 international_prefix: ''
 ioc:
 gec: IM

--- a/lib/data/countries/IN.yaml
+++ b/lib/data/countries/IN.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: IN
 alpha3: IND
 country_code: '91'
+emoji_flag: 🇮🇳
 international_prefix: '00'
 ioc: IND
 gec: IN

--- a/lib/data/countries/IO.yaml
+++ b/lib/data/countries/IO.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: IO
 alpha3: IOT
 country_code: '246'
+emoji_flag: 🇮🇴
 international_prefix: ''
 ioc:
 gec: IO

--- a/lib/data/countries/IQ.yaml
+++ b/lib/data/countries/IQ.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: IQ
 alpha3: IRQ
 country_code: '964'
+emoji_flag: 🇮🇶
 international_prefix: '00'
 ioc: IRQ
 gec: IZ

--- a/lib/data/countries/IR.yaml
+++ b/lib/data/countries/IR.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: IR
 alpha3: IRN
 country_code: '98'
+emoji_flag: 🇮🇷
 international_prefix: '00'
 ioc: IRI
 gec: IR

--- a/lib/data/countries/IS.yaml
+++ b/lib/data/countries/IS.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: IS
 alpha3: ISL
 country_code: '354'
+emoji_flag: 🇮🇸
 international_prefix: '00'
 ioc: ISL
 gec: IC

--- a/lib/data/countries/IT.yaml
+++ b/lib/data/countries/IT.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: IT
 alpha3: ITA
 country_code: '39'
+emoji_flag: 🇮🇹
 international_prefix: '00'
 ioc: ITA
 gec: IT

--- a/lib/data/countries/JE.yaml
+++ b/lib/data/countries/JE.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: JE
 alpha3: JEY
 country_code: '44'
+emoji_flag: 🇯🇪
 international_prefix: ''
 ioc:
 gec: JE

--- a/lib/data/countries/JM.yaml
+++ b/lib/data/countries/JM.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: JM
 alpha3: JAM
 country_code: '1'
+emoji_flag: 🇯🇲
 nanp_prefix: '1876'
 international_prefix: '011'
 ioc: JAM

--- a/lib/data/countries/JO.yaml
+++ b/lib/data/countries/JO.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: JO
 alpha3: JOR
 country_code: '962'
+emoji_flag: 🇯🇴
 international_prefix: '00'
 ioc: JOR
 gec: JO

--- a/lib/data/countries/JP.yaml
+++ b/lib/data/countries/JP.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: JP
 alpha3: JPN
 country_code: '81'
+emoji_flag: 🇯🇵
 international_prefix: '010'
 ioc: JPN
 gec: JA

--- a/lib/data/countries/KE.yaml
+++ b/lib/data/countries/KE.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: KE
 alpha3: KEN
 country_code: '254'
+emoji_flag: 🇰🇪
 international_prefix: '000'
 ioc: KEN
 gec: KE

--- a/lib/data/countries/KG.yaml
+++ b/lib/data/countries/KG.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: KG
 alpha3: KGZ
 country_code: '996'
+emoji_flag: 🇰🇬
 international_prefix: '00'
 ioc: KGZ
 gec: KG

--- a/lib/data/countries/KH.yaml
+++ b/lib/data/countries/KH.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: KH
 alpha3: KHM
 country_code: '855'
+emoji_flag: 🇰🇭
 international_prefix: '00'
 ioc: CAM
 gec: CB

--- a/lib/data/countries/KI.yaml
+++ b/lib/data/countries/KI.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: KI
 alpha3: KIR
 country_code: '686'
+emoji_flag: 🇰🇮
 international_prefix: '00'
 ioc: KIR
 gec: KR

--- a/lib/data/countries/KM.yaml
+++ b/lib/data/countries/KM.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: KM
 alpha3: COM
 country_code: '269'
+emoji_flag: 🇰🇲
 international_prefix: '00'
 ioc: COM
 gec: CN

--- a/lib/data/countries/KN.yaml
+++ b/lib/data/countries/KN.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: KN
 alpha3: KNA
 country_code: '1'
+emoji_flag: 🇰🇳
 nanp_prefix: '1869'
 international_prefix: '011'
 ioc: SKN

--- a/lib/data/countries/KP.yaml
+++ b/lib/data/countries/KP.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: KP
 alpha3: PRK
 country_code: '850'
+emoji_flag: 🇰🇵
 international_prefix: '00'
 ioc: PRK
 gec: KN

--- a/lib/data/countries/KR.yaml
+++ b/lib/data/countries/KR.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: KR
 alpha3: KOR
 country_code: '82'
+emoji_flag: 🇰🇷
 international_prefix: '001'
 ioc: KOR
 gec: KS

--- a/lib/data/countries/KW.yaml
+++ b/lib/data/countries/KW.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: KW
 alpha3: KWT
 country_code: '965'
+emoji_flag: 🇰🇼
 international_prefix: '00'
 ioc: KUW
 gec: KU

--- a/lib/data/countries/KY.yaml
+++ b/lib/data/countries/KY.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: KY
 alpha3: CYM
 country_code: '1'
+emoji_flag: 🇰🇾
 nanp_prefix: '1345'
 international_prefix: '011'
 ioc: CAY

--- a/lib/data/countries/KZ.yaml
+++ b/lib/data/countries/KZ.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: KZ
 alpha3: KAZ
 country_code: '7'
+emoji_flag: 🇰🇿
 international_prefix: '810'
 ioc: KAZ
 gec: KZ

--- a/lib/data/countries/LA.yaml
+++ b/lib/data/countries/LA.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: LA
 alpha3: LAO
 country_code: '856'
+emoji_flag: 🇱🇦
 international_prefix: '00'
 ioc: LAO
 gec: LA

--- a/lib/data/countries/LB.yaml
+++ b/lib/data/countries/LB.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: LB
 alpha3: LBN
 country_code: '961'
+emoji_flag: 🇱🇧
 international_prefix: '00'
 ioc: LIB
 gec: LE

--- a/lib/data/countries/LC.yaml
+++ b/lib/data/countries/LC.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: LC
 alpha3: LCA
 country_code: '1'
+emoji_flag: 🇱🇨
 nanp_prefix: '1758'
 international_prefix: '011'
 ioc: LCA

--- a/lib/data/countries/LI.yaml
+++ b/lib/data/countries/LI.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: LI
 alpha3: LIE
 country_code: '423'
+emoji_flag: 🇱🇮
 international_prefix: '00'
 ioc: LIE
 gec: LS

--- a/lib/data/countries/LK.yaml
+++ b/lib/data/countries/LK.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: LK
 alpha3: LKA
 country_code: '94'
+emoji_flag: 🇱🇰
 international_prefix: '00'
 ioc: SRI
 gec: CE

--- a/lib/data/countries/LR.yaml
+++ b/lib/data/countries/LR.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: LR
 alpha3: LBR
 country_code: '231'
+emoji_flag: 🇱🇷
 international_prefix: '00'
 ioc: LBR
 gec: LI

--- a/lib/data/countries/LS.yaml
+++ b/lib/data/countries/LS.yaml
@@ -4,6 +4,7 @@ alpha2: LS
 alpha3: LSO
 alt_currency: ZAR
 country_code: '266'
+emoji_flag: 🇱🇸
 international_prefix: '00'
 ioc: LES
 gec: LT

--- a/lib/data/countries/LT.yaml
+++ b/lib/data/countries/LT.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: LT
 alpha3: LTU
 country_code: '370'
+emoji_flag: 🇱🇹
 international_prefix: '00'
 ioc: LTU
 gec: LH

--- a/lib/data/countries/LU.yaml
+++ b/lib/data/countries/LU.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: LU
 alpha3: LUX
 country_code: '352'
+emoji_flag: 🇱🇺
 international_prefix: '00'
 ioc: LUX
 gec: LU

--- a/lib/data/countries/LV.yaml
+++ b/lib/data/countries/LV.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: LV
 alpha3: LVA
 country_code: '371'
+emoji_flag: 🇱🇻
 international_prefix: '00'
 ioc: LAT
 gec: LG

--- a/lib/data/countries/LY.yaml
+++ b/lib/data/countries/LY.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: LY
 alpha3: LBY
 country_code: '218'
+emoji_flag: 🇱🇾
 international_prefix: '00'
 ioc: LBA
 gec: LY

--- a/lib/data/countries/MA.yaml
+++ b/lib/data/countries/MA.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: MA
 alpha3: MAR
 country_code: '212'
+emoji_flag: 🇲🇦
 international_prefix: '00'
 ioc: MAR
 gec: MO

--- a/lib/data/countries/MC.yaml
+++ b/lib/data/countries/MC.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: MC
 alpha3: MCO
 country_code: '377'
+emoji_flag: 🇲🇨
 international_prefix: '00'
 ioc: MON
 gec: MN

--- a/lib/data/countries/MD.yaml
+++ b/lib/data/countries/MD.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: MD
 alpha3: MDA
 country_code: '373'
+emoji_flag: 🇲🇩
 international_prefix: '00'
 ioc: MDA
 gec: MD

--- a/lib/data/countries/ME.yaml
+++ b/lib/data/countries/ME.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: ME
 alpha3: MNE
 country_code: '382'
+emoji_flag: 🇲🇪
 international_prefix: '99'
 ioc: MNE
 gec: MJ

--- a/lib/data/countries/MF.yaml
+++ b/lib/data/countries/MF.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: MF
 alpha3: MAF
 country_code: '590'
+emoji_flag: 🇲🇫
 international_prefix: ''
 ioc:
 gec: RN

--- a/lib/data/countries/MG.yaml
+++ b/lib/data/countries/MG.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: MG
 alpha3: MDG
 country_code: '261'
+emoji_flag: 🇲🇬
 international_prefix: '00'
 ioc: MAD
 gec: MA

--- a/lib/data/countries/MH.yaml
+++ b/lib/data/countries/MH.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: MH
 alpha3: MHL
 country_code: '692'
+emoji_flag: 🇲🇭
 international_prefix: '00'
 ioc: MHL
 gec: RM

--- a/lib/data/countries/MK.yaml
+++ b/lib/data/countries/MK.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: MK
 alpha3: MKD
 country_code: '389'
+emoji_flag: 🇲🇰
 international_prefix: '00'
 ioc: MKD
 gec: MK

--- a/lib/data/countries/ML.yaml
+++ b/lib/data/countries/ML.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: ML
 alpha3: MLI
 country_code: '223'
+emoji_flag: 🇲🇱
 international_prefix: '00'
 ioc: MLI
 gec: ML

--- a/lib/data/countries/MM.yaml
+++ b/lib/data/countries/MM.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: MM
 alpha3: MMR
 country_code: '95'
+emoji_flag: 🇲🇲
 international_prefix: '00'
 ioc: MYA
 gec: BM

--- a/lib/data/countries/MN.yaml
+++ b/lib/data/countries/MN.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: MN
 alpha3: MNG
 country_code: '976'
+emoji_flag: 🇲🇳
 international_prefix: '001'
 ioc: MGL
 gec: MG

--- a/lib/data/countries/MO.yaml
+++ b/lib/data/countries/MO.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: MO
 alpha3: MAC
 country_code: '853'
+emoji_flag: 🇲🇴
 international_prefix: '00'
 ioc:
 gec: MC

--- a/lib/data/countries/MP.yaml
+++ b/lib/data/countries/MP.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: MP
 alpha3: MNP
 country_code: '1'
+emoji_flag: 🇲🇵
 international_prefix: '011'
 ioc:
 gec: CQ

--- a/lib/data/countries/MQ.yaml
+++ b/lib/data/countries/MQ.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: MQ
 alpha3: MTQ
 country_code: '596'
+emoji_flag: 🇲🇶
 international_prefix: '00'
 ioc:
 gec: MB

--- a/lib/data/countries/MR.yaml
+++ b/lib/data/countries/MR.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: MR
 alpha3: MRT
 country_code: '222'
+emoji_flag: 🇲🇷
 international_prefix: '00'
 ioc: MTN
 gec: MR

--- a/lib/data/countries/MS.yaml
+++ b/lib/data/countries/MS.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: MS
 alpha3: MSR
 country_code: '1'
+emoji_flag: 🇲🇸
 nanp_prefix: '1664'
 international_prefix: '011'
 ioc:

--- a/lib/data/countries/MT.yaml
+++ b/lib/data/countries/MT.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: MT
 alpha3: MLT
 country_code: '356'
+emoji_flag: 🇲🇹
 international_prefix: '00'
 ioc: MLT
 gec: MT

--- a/lib/data/countries/MU.yaml
+++ b/lib/data/countries/MU.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: MU
 alpha3: MUS
 country_code: '230'
+emoji_flag: 🇲🇺
 international_prefix: '020'
 ioc: MRI
 gec: MP

--- a/lib/data/countries/MV.yaml
+++ b/lib/data/countries/MV.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: MV
 alpha3: MDV
 country_code: '960'
+emoji_flag: 🇲🇻
 international_prefix: '00'
 ioc: MDV
 gec: MV

--- a/lib/data/countries/MW.yaml
+++ b/lib/data/countries/MW.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: MW
 alpha3: MWI
 country_code: '265'
+emoji_flag: 🇲🇼
 international_prefix: '00'
 ioc: MAW
 gec: MI

--- a/lib/data/countries/MX.yaml
+++ b/lib/data/countries/MX.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: MX
 alpha3: MEX
 country_code: '52'
+emoji_flag: 🇲🇽
 international_prefix: '00'
 ioc: MEX
 gec: MX

--- a/lib/data/countries/MY.yaml
+++ b/lib/data/countries/MY.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: MY
 alpha3: MYS
 country_code: '60'
+emoji_flag: 🇲🇾
 international_prefix: '00'
 ioc: MAS
 gec: MY

--- a/lib/data/countries/MZ.yaml
+++ b/lib/data/countries/MZ.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: MZ
 alpha3: MOZ
 country_code: '258'
+emoji_flag: 🇲🇿
 international_prefix: '00'
 ioc: MOZ
 gec: MZ

--- a/lib/data/countries/NA.yaml
+++ b/lib/data/countries/NA.yaml
@@ -4,6 +4,7 @@ alpha2: NA
 alpha3: NAM
 alt_currency: ZAR
 country_code: '264'
+emoji_flag: 🇳🇦
 international_prefix: '00'
 ioc: NAM
 gec: WA

--- a/lib/data/countries/NC.yaml
+++ b/lib/data/countries/NC.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: NC
 alpha3: NCL
 country_code: '687'
+emoji_flag: 🇳🇨
 international_prefix: '00'
 ioc:
 gec: NC

--- a/lib/data/countries/NE.yaml
+++ b/lib/data/countries/NE.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: NE
 alpha3: NER
 country_code: '227'
+emoji_flag: 🇳🇪
 international_prefix: '00'
 ioc: NIG
 gec: NG

--- a/lib/data/countries/NF.yaml
+++ b/lib/data/countries/NF.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: NF
 alpha3: NFK
 country_code: '672'
+emoji_flag: 🇳🇫
 international_prefix: '00'
 ioc:
 gec: NF

--- a/lib/data/countries/NG.yaml
+++ b/lib/data/countries/NG.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: NG
 alpha3: NGA
 country_code: '234'
+emoji_flag: 🇳🇬
 international_prefix: 009
 ioc: NGR
 gec: NI

--- a/lib/data/countries/NI.yaml
+++ b/lib/data/countries/NI.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: NI
 alpha3: NIC
 country_code: '505'
+emoji_flag: 🇳🇮
 international_prefix: '00'
 ioc: NCA
 gec: NU

--- a/lib/data/countries/NL.yaml
+++ b/lib/data/countries/NL.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: NL
 alpha3: NLD
 country_code: '31'
+emoji_flag: 🇳🇱
 international_prefix: '00'
 ioc: NED
 gec: NL

--- a/lib/data/countries/NO.yaml
+++ b/lib/data/countries/NO.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: 'NO'
 alpha3: NOR
 country_code: '47'
+emoji_flag: 🇳🇴
 international_prefix: '00'
 ioc: NOR
 gec: 'NO'

--- a/lib/data/countries/NP.yaml
+++ b/lib/data/countries/NP.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: NP
 alpha3: NPL
 country_code: '977'
+emoji_flag: 🇳🇵
 international_prefix: '00'
 ioc: NEP
 gec: NP

--- a/lib/data/countries/NR.yaml
+++ b/lib/data/countries/NR.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: NR
 alpha3: NRU
 country_code: '674'
+emoji_flag: 🇳🇷
 international_prefix: '00'
 ioc: NRU
 gec: NR

--- a/lib/data/countries/NU.yaml
+++ b/lib/data/countries/NU.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: NU
 alpha3: NIU
 country_code: '683'
+emoji_flag: 🇳🇺
 international_prefix: '00'
 ioc:
 gec: NE

--- a/lib/data/countries/NZ.yaml
+++ b/lib/data/countries/NZ.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: NZ
 alpha3: NZL
 country_code: '64'
+emoji_flag: 🇳🇿
 international_prefix: '00'
 ioc: NZL
 gec: NZ

--- a/lib/data/countries/OM.yaml
+++ b/lib/data/countries/OM.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: OM
 alpha3: OMN
 country_code: '968'
+emoji_flag: 🇴🇲
 international_prefix: '00'
 ioc: OMA
 gec: MU

--- a/lib/data/countries/PA.yaml
+++ b/lib/data/countries/PA.yaml
@@ -4,6 +4,7 @@ alpha2: PA
 alpha3: PAN
 alt_currency: USD
 country_code: '507'
+emoji_flag: 🇵🇦
 international_prefix: '00'
 ioc: PAN
 gec: PM

--- a/lib/data/countries/PE.yaml
+++ b/lib/data/countries/PE.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: PE
 alpha3: PER
 country_code: '51'
+emoji_flag: 🇵🇪
 international_prefix: '00'
 ioc: PER
 gec: PE

--- a/lib/data/countries/PF.yaml
+++ b/lib/data/countries/PF.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: PF
 alpha3: PYF
 country_code: '689'
+emoji_flag: 🇵🇫
 international_prefix: '00'
 ioc:
 gec: FP

--- a/lib/data/countries/PG.yaml
+++ b/lib/data/countries/PG.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: PG
 alpha3: PNG
 country_code: '675'
+emoji_flag: 🇵🇬
 international_prefix: '05'
 ioc: PNG
 gec: PP

--- a/lib/data/countries/PH.yaml
+++ b/lib/data/countries/PH.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: PH
 alpha3: PHL
 country_code: '63'
+emoji_flag: 🇵🇭
 international_prefix: '00'
 ioc: PHI
 gec: RP

--- a/lib/data/countries/PK.yaml
+++ b/lib/data/countries/PK.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: PK
 alpha3: PAK
 country_code: '92'
+emoji_flag: 🇵🇰
 international_prefix: '00'
 ioc: PAK
 gec: PK

--- a/lib/data/countries/PL.yaml
+++ b/lib/data/countries/PL.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: PL
 alpha3: POL
 country_code: '48'
+emoji_flag: 🇵🇱
 international_prefix: '00'
 ioc: POL
 gec: PL

--- a/lib/data/countries/PM.yaml
+++ b/lib/data/countries/PM.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: PM
 alpha3: SPM
 country_code: '508'
+emoji_flag: 🇵🇲
 international_prefix: '00'
 ioc:
 gec: SB

--- a/lib/data/countries/PN.yaml
+++ b/lib/data/countries/PN.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: PN
 alpha3: PCN
 country_code: '64'
+emoji_flag: 🇵🇳
 international_prefix: '00'
 ioc:
 gec: PC

--- a/lib/data/countries/PR.yaml
+++ b/lib/data/countries/PR.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: PR
 alpha3: PRI
 country_code: '1'
+emoji_flag: 🇵🇷
 international_prefix: '011'
 ioc: PUR
 gec: RQ

--- a/lib/data/countries/PS.yaml
+++ b/lib/data/countries/PS.yaml
@@ -4,6 +4,7 @@ alpha2: PS
 alpha3: PSE
 alt_currency: EGP
 country_code: '970'
+emoji_flag: 🇵🇸
 international_prefix: '00'
 ioc: PLE
 gec: WE

--- a/lib/data/countries/PT.yaml
+++ b/lib/data/countries/PT.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: PT
 alpha3: PRT
 country_code: '351'
+emoji_flag: 🇵🇹
 international_prefix: '00'
 ioc: POR
 gec: PO

--- a/lib/data/countries/PW.yaml
+++ b/lib/data/countries/PW.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: PW
 alpha3: PLW
 country_code: '680'
+emoji_flag: 🇵🇼
 international_prefix: '00'
 ioc: PLW
 gec: PS

--- a/lib/data/countries/PY.yaml
+++ b/lib/data/countries/PY.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: PY
 alpha3: PRY
 country_code: '595'
+emoji_flag: 🇵🇾
 international_prefix: '002'
 ioc: PAR
 gec: PA

--- a/lib/data/countries/QA.yaml
+++ b/lib/data/countries/QA.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: QA
 alpha3: QAT
 country_code: '974'
+emoji_flag: 🇶🇦
 international_prefix: '00'
 ioc: QAT
 gec: QA

--- a/lib/data/countries/RE.yaml
+++ b/lib/data/countries/RE.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: RE
 alpha3: REU
 country_code: '262'
+emoji_flag: 🇷🇪
 international_prefix: '00'
 ioc:
 gec: RE

--- a/lib/data/countries/RO.yaml
+++ b/lib/data/countries/RO.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: RO
 alpha3: ROU
 country_code: '40'
+emoji_flag: 🇷🇴
 international_prefix: '00'
 ioc: ROU
 gec: RO

--- a/lib/data/countries/RS.yaml
+++ b/lib/data/countries/RS.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: RS
 alpha3: SRB
 country_code: '381'
+emoji_flag: 🇷🇸
 international_prefix: '99'
 ioc: SRB
 gec: RI

--- a/lib/data/countries/RU.yaml
+++ b/lib/data/countries/RU.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: RU
 alpha3: RUS
 country_code: '7'
+emoji_flag: 🇷🇺
 international_prefix: '810'
 ioc: RUS
 gec: RS

--- a/lib/data/countries/RW.yaml
+++ b/lib/data/countries/RW.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: RW
 alpha3: RWA
 country_code: '250'
+emoji_flag: 🇷🇼
 international_prefix: '00'
 ioc: RWA
 gec: RW

--- a/lib/data/countries/SA.yaml
+++ b/lib/data/countries/SA.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: SA
 alpha3: SAU
 country_code: '966'
+emoji_flag: 🇸🇦
 international_prefix: '00'
 ioc: KSA
 gec: SA

--- a/lib/data/countries/SB.yaml
+++ b/lib/data/countries/SB.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: SB
 alpha3: SLB
 country_code: '677'
+emoji_flag: 🇸🇧
 international_prefix: '00'
 ioc: SOL
 gec: BP

--- a/lib/data/countries/SC.yaml
+++ b/lib/data/countries/SC.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: SC
 alpha3: SYC
 country_code: '248'
+emoji_flag: 🇸🇨
 international_prefix: '00'
 ioc: SEY
 gec: SE

--- a/lib/data/countries/SD.yaml
+++ b/lib/data/countries/SD.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: SD
 alpha3: SDN
 country_code: '249'
+emoji_flag: 🇸🇩
 international_prefix: '00'
 ioc: SUD
 gec: SU

--- a/lib/data/countries/SE.yaml
+++ b/lib/data/countries/SE.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: SE
 alpha3: SWE
 country_code: '46'
+emoji_flag: 🇸🇪
 international_prefix: '00'
 ioc: SWE
 gec: SW

--- a/lib/data/countries/SG.yaml
+++ b/lib/data/countries/SG.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: SG
 alpha3: SGP
 country_code: '65'
+emoji_flag: 🇸🇬
 international_prefix: '001'
 ioc: SIN
 gec: SN

--- a/lib/data/countries/SH.yaml
+++ b/lib/data/countries/SH.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: SH
 alpha3: SHN
 country_code: '290'
+emoji_flag: 🇸🇭
 international_prefix: '00'
 ioc:
 gec: SH

--- a/lib/data/countries/SI.yaml
+++ b/lib/data/countries/SI.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: SI
 alpha3: SVN
 country_code: '386'
+emoji_flag: 🇸🇮
 international_prefix: '00'
 ioc: SLO
 gec: SI

--- a/lib/data/countries/SJ.yaml
+++ b/lib/data/countries/SJ.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: SJ
 alpha3: SJM
 country_code: '47'
+emoji_flag: 🇸🇯
 international_prefix: '00'
 ioc:
 gec: SV

--- a/lib/data/countries/SK.yaml
+++ b/lib/data/countries/SK.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: SK
 alpha3: SVK
 country_code: '421'
+emoji_flag: 🇸🇰
 international_prefix: '00'
 ioc: SVK
 gec: LO

--- a/lib/data/countries/SL.yaml
+++ b/lib/data/countries/SL.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: SL
 alpha3: SLE
 country_code: '232'
+emoji_flag: 🇸🇱
 international_prefix: '00'
 ioc: SLE
 gec: SL

--- a/lib/data/countries/SM.yaml
+++ b/lib/data/countries/SM.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: SM
 alpha3: SMR
 country_code: '378'
+emoji_flag: 🇸🇲
 international_prefix: '00'
 ioc: SMR
 gec: SM

--- a/lib/data/countries/SN.yaml
+++ b/lib/data/countries/SN.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: SN
 alpha3: SEN
 country_code: '221'
+emoji_flag: 🇸🇳
 international_prefix: '00'
 ioc: SEN
 gec: SG

--- a/lib/data/countries/SO.yaml
+++ b/lib/data/countries/SO.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: SO
 alpha3: SOM
 country_code: '252'
+emoji_flag: 🇸🇴
 international_prefix: '00'
 ioc: SOM
 gec: SO

--- a/lib/data/countries/SR.yaml
+++ b/lib/data/countries/SR.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: SR
 alpha3: SUR
 country_code: '597'
+emoji_flag: 🇸🇷
 international_prefix: '00'
 ioc: SUR
 gec: NS

--- a/lib/data/countries/SS.yaml
+++ b/lib/data/countries/SS.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: SS
 alpha3: SSD
 country_code: '211'
+emoji_flag: 🇸🇸
 international_prefix: '0'
 ioc:
 gec: OD

--- a/lib/data/countries/ST.yaml
+++ b/lib/data/countries/ST.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: ST
 alpha3: STP
 country_code: '239'
+emoji_flag: 🇸🇹
 international_prefix: '00'
 ioc: STP
 gec: TP

--- a/lib/data/countries/SV.yaml
+++ b/lib/data/countries/SV.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: SV
 alpha3: SLV
 country_code: '503'
+emoji_flag: 🇸🇻
 international_prefix: '00'
 ioc: ESA
 gec: ES

--- a/lib/data/countries/SX.yaml
+++ b/lib/data/countries/SX.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: SX
 alpha3: SXM
 country_code: '1'
+emoji_flag: 🇸🇽
 nanp_prefix: '1721'
 international_prefix: '011'
 ioc:

--- a/lib/data/countries/SY.yaml
+++ b/lib/data/countries/SY.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: SY
 alpha3: SYR
 country_code: '963'
+emoji_flag: 🇸🇾
 international_prefix: '00'
 ioc: SYR
 gec: SY

--- a/lib/data/countries/SZ.yaml
+++ b/lib/data/countries/SZ.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: SZ
 alpha3: SWZ
 country_code: '268'
+emoji_flag: 🇸🇿
 international_prefix: '00'
 ioc: SWZ
 gec: WZ

--- a/lib/data/countries/TC.yaml
+++ b/lib/data/countries/TC.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: TC
 alpha3: TCA
 country_code: '1'
+emoji_flag: 🇹🇨
 nanp_prefix: '1649'
 international_prefix: '011'
 ioc:

--- a/lib/data/countries/TD.yaml
+++ b/lib/data/countries/TD.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: TD
 alpha3: TCD
 country_code: '235'
+emoji_flag: 🇹🇩
 international_prefix: '15'
 ioc: CHA
 gec: CD

--- a/lib/data/countries/TF.yaml
+++ b/lib/data/countries/TF.yaml
@@ -3,6 +3,7 @@ continent: Antarctica
 alpha2: TF
 alpha3: ATF
 country_code: '262'
+emoji_flag: 🇹🇫
 international_prefix: ''
 ioc:
 gec: FS

--- a/lib/data/countries/TG.yaml
+++ b/lib/data/countries/TG.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: TG
 alpha3: TGO
 country_code: '228'
+emoji_flag: 🇹🇬
 international_prefix: '00'
 ioc: TOG
 gec: TO

--- a/lib/data/countries/TH.yaml
+++ b/lib/data/countries/TH.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: TH
 alpha3: THA
 country_code: '66'
+emoji_flag: 🇹🇭
 international_prefix: '001'
 ioc: THA
 gec: TH

--- a/lib/data/countries/TJ.yaml
+++ b/lib/data/countries/TJ.yaml
@@ -4,6 +4,7 @@ alpha2: TJ
 alpha3: TJK
 alt_currency: RUB
 country_code: '992'
+emoji_flag: 🇹🇯
 international_prefix: '810'
 ioc: TJK
 gec: TI

--- a/lib/data/countries/TK.yaml
+++ b/lib/data/countries/TK.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: TK
 alpha3: TKL
 country_code: '690'
+emoji_flag: 🇹🇰
 international_prefix: '00'
 ioc:
 gec: TL

--- a/lib/data/countries/TL.yaml
+++ b/lib/data/countries/TL.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: TL
 alpha3: TLS
 country_code: '670'
+emoji_flag: 🇹🇱
 international_prefix: None
 ioc: TLS
 gec: TT

--- a/lib/data/countries/TM.yaml
+++ b/lib/data/countries/TM.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: TM
 alpha3: TKM
 country_code: '993'
+emoji_flag: 🇹🇲
 international_prefix: '810'
 ioc: TKM
 gec: TX

--- a/lib/data/countries/TN.yaml
+++ b/lib/data/countries/TN.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: TN
 alpha3: TUN
 country_code: '216'
+emoji_flag: 🇹🇳
 international_prefix: '00'
 ioc: TUN
 gec: TS

--- a/lib/data/countries/TO.yaml
+++ b/lib/data/countries/TO.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: TO
 alpha3: TON
 country_code: '676'
+emoji_flag: 🇹🇴
 international_prefix: '00'
 ioc: TGA
 gec: TN

--- a/lib/data/countries/TR.yaml
+++ b/lib/data/countries/TR.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: TR
 alpha3: TUR
 country_code: '90'
+emoji_flag: 🇹🇷
 international_prefix: '00'
 ioc: TUR
 gec: TU

--- a/lib/data/countries/TT.yaml
+++ b/lib/data/countries/TT.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: TT
 alpha3: TTO
 country_code: '1'
+emoji_flag: 🇹🇹
 nanp_prefix: '1868'
 international_prefix: '011'
 ioc: TRI

--- a/lib/data/countries/TV.yaml
+++ b/lib/data/countries/TV.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: TV
 alpha3: TUV
 country_code: '688'
+emoji_flag: 🇹🇻
 international_prefix: '00'
 ioc: TUV
 gec: TV

--- a/lib/data/countries/TW.yaml
+++ b/lib/data/countries/TW.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: TW
 alpha3: TWN
 country_code: '886'
+emoji_flag: 🇹🇼
 international_prefix: '002'
 ioc: TPE
 gec: TW

--- a/lib/data/countries/TZ.yaml
+++ b/lib/data/countries/TZ.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: TZ
 alpha3: TZA
 country_code: '255'
+emoji_flag: 🇹🇿
 international_prefix: '000'
 ioc: TAN
 gec: TZ

--- a/lib/data/countries/UA.yaml
+++ b/lib/data/countries/UA.yaml
@@ -9,6 +9,7 @@ address_format: |-
 alpha2: UA
 alpha3: UKR
 country_code: '380'
+emoji_flag: 🇺🇦
 international_prefix: '810'
 ioc: UKR
 gec: UP

--- a/lib/data/countries/UG.yaml
+++ b/lib/data/countries/UG.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: UG
 alpha3: UGA
 country_code: '256'
+emoji_flag: 🇺🇬
 international_prefix: '000'
 ioc: UGA
 gec: UG

--- a/lib/data/countries/UM.yaml
+++ b/lib/data/countries/UM.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: UM
 alpha3: UMI
 country_code: '1'
+emoji_flag: 🇺🇲
 international_prefix: ''
 ioc:
 gec:

--- a/lib/data/countries/US.yaml
+++ b/lib/data/countries/US.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: US
 alpha3: USA
 country_code: '1'
+emoji_flag: 🇺🇸
 international_prefix: '011'
 ioc: USA
 gec: US

--- a/lib/data/countries/UY.yaml
+++ b/lib/data/countries/UY.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: UY
 alpha3: URY
 country_code: '598'
+emoji_flag: 🇺🇾
 international_prefix: '00'
 ioc: URU
 gec: UY

--- a/lib/data/countries/UZ.yaml
+++ b/lib/data/countries/UZ.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: UZ
 alpha3: UZB
 country_code: '998'
+emoji_flag: 🇺🇿
 international_prefix: '810'
 ioc: UZB
 gec: UZ

--- a/lib/data/countries/VA.yaml
+++ b/lib/data/countries/VA.yaml
@@ -3,6 +3,7 @@ continent: Europe
 alpha2: VA
 alpha3: VAT
 country_code: '39'
+emoji_flag: 🇻🇦
 international_prefix: '00'
 ioc:
 gec: VT

--- a/lib/data/countries/VC.yaml
+++ b/lib/data/countries/VC.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: VC
 alpha3: VCT
 country_code: '1'
+emoji_flag: 🇻🇨
 nanp_prefix: '1784'
 international_prefix: '011'
 ioc: VIN

--- a/lib/data/countries/VE.yaml
+++ b/lib/data/countries/VE.yaml
@@ -3,6 +3,7 @@ continent: South America
 alpha2: VE
 alpha3: VEN
 country_code: '58'
+emoji_flag: 🇻🇪
 international_prefix: '00'
 ioc: VEN
 gec: VE

--- a/lib/data/countries/VG.yaml
+++ b/lib/data/countries/VG.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: VG
 alpha3: VGB
 country_code: '1'
+emoji_flag: 🇻🇬
 nanp_prefix: '1284'
 international_prefix: '011'
 ioc: IVB

--- a/lib/data/countries/VI.yaml
+++ b/lib/data/countries/VI.yaml
@@ -3,6 +3,7 @@ continent: North America
 alpha2: VI
 alpha3: VIR
 country_code: '1'
+emoji_flag: 🇻🇮
 international_prefix: '011'
 ioc: ISV
 gec: VQ

--- a/lib/data/countries/VN.yaml
+++ b/lib/data/countries/VN.yaml
@@ -3,6 +3,7 @@ continent: Asia
 alpha2: VN
 alpha3: VNM
 country_code: '84'
+emoji_flag: 🇻🇳
 international_prefix: '00'
 ioc: VIE
 gec: VM

--- a/lib/data/countries/VU.yaml
+++ b/lib/data/countries/VU.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: VU
 alpha3: VUT
 country_code: '678'
+emoji_flag: 🇻🇺
 international_prefix: '00'
 ioc: VAN
 gec: NH

--- a/lib/data/countries/WF.yaml
+++ b/lib/data/countries/WF.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: WF
 alpha3: WLF
 country_code: '681'
+emoji_flag: 🇼🇫
 international_prefix: '19'
 ioc:
 gec: WF

--- a/lib/data/countries/WS.yaml
+++ b/lib/data/countries/WS.yaml
@@ -3,6 +3,7 @@ continent: Australia
 alpha2: WS
 alpha3: WSM
 country_code: '685'
+emoji_flag: 🇼🇸
 international_prefix: '00'
 ioc: SAM
 gec: WS

--- a/lib/data/countries/YE.yaml
+++ b/lib/data/countries/YE.yaml
@@ -8,6 +8,7 @@ address_format: |-
 alpha2: YE
 alpha3: YEM
 country_code: '967'
+emoji_flag: 🇾🇪
 international_prefix: '00'
 ioc: YEM
 gec: YM

--- a/lib/data/countries/YT.yaml
+++ b/lib/data/countries/YT.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: YT
 alpha3: MYT
 country_code: '262'
+emoji_flag: 🇾🇹
 international_prefix: '00'
 ioc:
 gec: MF

--- a/lib/data/countries/ZA.yaml
+++ b/lib/data/countries/ZA.yaml
@@ -10,6 +10,7 @@ address_format: |-
 alpha2: ZA
 alpha3: ZAF
 country_code: '27'
+emoji_flag: 🇿🇦
 international_prefix: 09
 ioc: RSA
 gec: SF

--- a/lib/data/countries/ZM.yaml
+++ b/lib/data/countries/ZM.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: ZM
 alpha3: ZMB
 country_code: '260'
+emoji_flag: 🇿🇲
 international_prefix: '00'
 ioc: ZAM
 gec: ZA

--- a/lib/data/countries/ZW.yaml
+++ b/lib/data/countries/ZW.yaml
@@ -3,6 +3,7 @@ continent: Africa
 alpha2: ZW
 alpha3: ZWE
 country_code: '263'
+emoji_flag: 🇿🇼
 international_prefix: '00'
 ioc: ZIM
 gec: ZI

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Countries.Mixfile do
   use Mix.Project
 
-  @version "1.5.0"
+  @version "1.6.0"
 
   def project do
     [app: :countries,


### PR DESCRIPTION
Adding the emoji_flag property known from the excellent countries gem for ruby.

However, it's missing the flag for Netherlands Antilles because I couldn't find an emoji for that flag. Just went with `white flat`, any other suggestions?