### PR TITLE
Fix compiler warning.

### DIFF
--- a/lib/loader.ex
+++ b/lib/loader.ex
@@ -52,7 +52,7 @@ defmodule Countries.Loader do
     do: to_map(values)
 
   defp convert_value(attribute, value)
-    when is_list(value) and not attribute in @do_not_convert,
+    when is_list(value) and not (attribute in @do_not_convert),
     do: to_string(value)
 
   defp convert_value(_, value),


### PR DESCRIPTION
```
==> countries
Compiling 6 files (.ex)
warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions
  lib/loader.ex:55

Generated countries app
```

This will allow `mix compile --warnings-as-errors` to be added to CI, should you want to do that. 