### PR TITLE
Relax yamerl version.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Countries.Mixfile do
   end
 
   defp deps do
-    [{:yamerl, "~> 0.4.0"},
+    [{:yamerl, "~> 0.4"},
      {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 


### PR DESCRIPTION
No need to pin to a patch version here. This causes people to need to override when trying to bump `:yamerl`.