### PR TITLE
Improved filter_by comparison

### DIFF
--- a/lib/countries.ex
+++ b/lib/countries.ex
@@ -29,18 +29,37 @@ defmodule Countries do
   """
   def filter_by(attribute, value) do
     Enum.filter(countries(), fn country ->
-      Map.get(country, attribute)
+      country
+      |> Map.get(attribute)
       |> equals_or_contains_in_list(value)
     end)
   end
 
-  defp equals_or_contains_in_list(attribute, value) when is_list(attribute) do
-    Enum.member?(attribute, value)
+  defp equals_or_contains_in_list(nil, _), do: false
+  defp equals_or_contains_in_list([], _), do: false
+
+  defp equals_or_contains_in_list([attribute | rest], value) do
+    if equals_or_contains_in_list(attribute, value) do
+      true
+    else
+      equals_or_contains_in_list(rest, value)
+    end
   end
 
-  defp equals_or_contains_in_list(attribute, value) do
-    attribute == value
-  end
+  defp equals_or_contains_in_list(attribute, value),
+    do: normalize(attribute) == normalize(value)
+
+  defp normalize(value) when is_integer(value),
+    do: value |> Integer.to_string() |> normalize()
+
+  defp normalize(value) when is_binary(value),
+    do:
+      value
+      |> String.downcase()
+      |> String.trim()
+      |> String.replace(~r/\s+/, "")
+
+  defp normalize(value), do: value
 
   @doc """
   Checks if country for specific attribute and value exists.

--- a/lib/countries.ex
+++ b/lib/countries.ex
@@ -53,11 +53,7 @@ defmodule Countries do
     do: value |> Integer.to_string() |> normalize()
 
   defp normalize(value) when is_binary(value),
-    do:
-      value
-      |> String.downcase()
-      |> String.trim()
-      |> String.replace(~r/\s+/, "")
+    do: value |> String.downcase() |> String.replace(~r/\s+/, "")
 
   defp normalize(value), do: value
 

--- a/test/countries_test.exs
+++ b/test/countries_test.exs
@@ -33,15 +33,24 @@ defmodule CountriesTest do
     test "filters countries by alpha2" do
       country = Countries.filter_by(:alpha2, "DE")
       assert Enum.count(country) == 1
+
+      country = Countries.filter_by(:alpha2, "sm")
+      assert Enum.count(country) == 1
     end
 
     test "filters countries by alpha3" do
       country = Countries.filter_by(:alpha3, "VCT")
       assert Enum.count(country) == 1
+
+      country = Countries.filter_by(:alpha3, "hun")
+      assert Enum.count(country) == 1
     end
 
     test "filters countries by name" do
       country = Countries.filter_by(:name, "Aruba")
+      assert Enum.count(country) == 1
+
+      country = Countries.filter_by(:name, "estonia")
       assert Enum.count(country) == 1
     end
 

--- a/test/countries_test.exs
+++ b/test/countries_test.exs
@@ -16,11 +16,8 @@ defmodule CountriesTest do
 
   describe "exists?/2" do
     test "checks if country exists" do
-      country_exists = Countries.exists?(:name, "Poland")
-      assert country_exists == true
-
-      country_exists = Countries.exists?(:name, "Polande")
-      assert country_exists == false
+      assert Countries.exists?(:name, "Poland")
+      refute Countries.exists?(:name, "Polande")
     end
   end
 
@@ -31,40 +28,31 @@ defmodule CountriesTest do
     end
 
     test "filters countries by alpha2" do
-      country = Countries.filter_by(:alpha2, "DE")
-      assert Enum.count(country) == 1
-
-      country = Countries.filter_by(:alpha2, "sm")
-      assert Enum.count(country) == 1
+      [%{alpha3: "DEU"}] = Countries.filter_by(:alpha2, "DE")
+      [%{alpha3: "SMR"}] = Countries.filter_by(:alpha2, "sm")
     end
 
     test "filters countries by alpha3" do
-      country = Countries.filter_by(:alpha3, "VCT")
-      assert Enum.count(country) == 1
-
-      country = Countries.filter_by(:alpha3, "hun")
-      assert Enum.count(country) == 1
+      [%{alpha2: "VC"}] = Countries.filter_by(:alpha3, "VCT")
+      [%{alpha2: "HU"}] = Countries.filter_by(:alpha3, "hun")
     end
 
     test "filters countries by name" do
-      country = Countries.filter_by(:name, "Aruba")
-      assert Enum.count(country) == 1
-
-      country = Countries.filter_by(:name, "estonia")
-      assert Enum.count(country) == 1
+      [%{alpha2: "AW"}] = Countries.filter_by(:name, "Aruba")
+      [%{alpha2: "EE"}] = Countries.filter_by(:name, "estonia")
     end
 
     test "filter countries by unofficial names" do
-      assert [_] = Countries.filter_by(:unofficial_names, "Reino Unido")
-      assert [_] = Countries.filter_by(:unofficial_names, "The United Kingdom")
-      assert [_] = Countries.filter_by(:unofficial_names, "États-Unis")
-      assert [_] = Countries.filter_by(:unofficial_names, "アメリカ合衆国")
-      assert [_] = Countries.filter_by(:unofficial_names, "Россия")
-      assert [_] = Countries.filter_by(:unofficial_names, "لبنان")
+      [%{alpha2: "GB"}] = Countries.filter_by(:unofficial_names, "Reino Unido")
+      [%{alpha2: "GB"}] = Countries.filter_by(:unofficial_names, "The United Kingdom")
+      [%{alpha2: "US"}] = Countries.filter_by(:unofficial_names, "États-Unis")
+      [%{alpha2: "US"}] = Countries.filter_by(:unofficial_names, "アメリカ合衆国")
+      [%{alpha2: "RU"}] = Countries.filter_by(:unofficial_names, "Россия")
+      [%{alpha2: "LB"}] = Countries.filter_by(:unofficial_names, "لبنان")
     end
 
     test "filters countries with basic string sanitization" do
-      assert [_] = Countries.filter_by(:name, "\npuerto    rico \n   ")
+      [%{alpha2: "PR"}] = Countries.filter_by(:name, "\npuerto    rico \n   ")
 
       countries = Countries.filter_by(:subregion, "WESTERNEUROPE")
       assert Enum.count(countries) == 9

--- a/test/countries_test.exs
+++ b/test/countries_test.exs
@@ -1,39 +1,83 @@
 defmodule CountriesTest do
   use ExUnit.Case, async: true
 
-  test "filter countries by alpha2" do
-    country = Countries.filter_by(:alpha2, "DE")
-    assert Enum.count(country) == 1
+  describe "all/0" do
+    test "get all countries" do
+      countries = Countries.all()
+      assert Enum.count(countries) == 250
+    end
   end
 
-  test "filter countries by name" do
-    countries = Countries.filter_by(:name, "United Kingdom of Great Britain and Northern Ireland")
-    assert Enum.count(countries) == 1
+  describe "get/1" do
+    test "gets one country" do
+      %{alpha2: "GB"} = Countries.get("GB")
+    end
   end
 
-  test "filter countries by alternative names" do
-    assert [_] = Countries.filter_by(:unofficial_names, "Reino Unido")
+  describe "exists?/2" do
+    test "checks if country exists" do
+      country_exists = Countries.exists?(:name, "Poland")
+      assert country_exists == true
 
-    assert [_] = Countries.filter_by(:unofficial_names, "The United Kingdom")
+      country_exists = Countries.exists?(:name, "Polande")
+      assert country_exists == false
+    end
   end
 
-  test "get one country" do
-    %{alpha2: "GB"} = Countries.get("GB")
-  end
+  describe "filter_by/2" do
+    test "return empty list when there are no results" do
+      countries = Countries.filter_by(:region, "Azeroth")
+      assert countries == []
+    end
 
-  test "filter many countries by region" do
-    countries = Countries.filter_by(:region, "Europe")
-    assert Enum.count(countries) == 51
-  end
+    test "filters countries by alpha2" do
+      country = Countries.filter_by(:alpha2, "DE")
+      assert Enum.count(country) == 1
+    end
 
-  test "return empty list when there are no results" do
-    countries = Countries.filter_by(:region, "Azeroth")
-    assert countries == []
-  end
+    test "filters countries by alpha3" do
+      country = Countries.filter_by(:alpha3, "VCT")
+      assert Enum.count(country) == 1
+    end
 
-  test "get all countries" do
-    countries = Countries.all()
-    assert Enum.count(countries) == 250
+    test "filters countries by name" do
+      country = Countries.filter_by(:name, "Aruba")
+      assert Enum.count(country) == 1
+    end
+
+    test "filter countries by unofficial names" do
+      assert [_] = Countries.filter_by(:unofficial_names, "Reino Unido")
+      assert [_] = Countries.filter_by(:unofficial_names, "The United Kingdom")
+      assert [_] = Countries.filter_by(:unofficial_names, "États-Unis")
+      assert [_] = Countries.filter_by(:unofficial_names, "アメリカ合衆国")
+      assert [_] = Countries.filter_by(:unofficial_names, "Россия")
+      assert [_] = Countries.filter_by(:unofficial_names, "لبنان")
+    end
+
+    test "filters countries with basic string sanitization" do
+      assert [_] = Countries.filter_by(:name, "\npuerto    rico \n   ")
+
+      countries = Countries.filter_by(:subregion, "WESTERNEUROPE")
+      assert Enum.count(countries) == 9
+    end
+
+    test "filters many countries by region" do
+      countries = Countries.filter_by(:region, "Europe")
+      assert Enum.count(countries) == 51
+    end
+
+    test "filters by official language" do
+      countries = Countries.filter_by(:languages_official, "EN")
+      assert Enum.count(countries) == 48
+    end
+
+    test "filters by integer attributes" do
+      countries = Countries.filter_by(:national_number_lengths, 10)
+      assert Enum.count(countries) == 59
+
+      countries = Countries.filter_by(:national_destination_code_lengths, "2")
+      assert Enum.count(countries) == 200
+    end
   end
 
   test "get country subdivisions" do
@@ -45,13 +89,5 @@ defmodule CountriesTest do
 
     country = List.first(Countries.filter_by(:alpha2, "AI"))
     assert Enum.count(Countries.Subdivisions.all(country)) == 14
-  end
-
-  test "checks if country exists" do
-    country_exists = Countries.exists?(:name, "Poland")
-    assert country_exists == true
-
-    country_exists = Countries.exists?(:name, "Polande")
-    assert country_exists == false
   end
 end


### PR DESCRIPTION
Currently the `Countries.filter_by/2` function does direct string comparisons to return matching results. As such, filtering by a slightly mismatched string will not return any results, ex. `Countries.filter_by(:name, "puerto rico")` returns an empty list.

This PR adds a basic layer of data normalization to the values being compared in order to allow for better filtering results.