### PR TITLE
:pencil: Doc tests, code blocks & more examples

### DIFF
--- a/lib/countries.ex
+++ b/lib/countries.ex
@@ -7,7 +7,13 @@ defmodule Countries do
   end
 
   @doc """
-    Returns one country gived is alpha2 country code
+  Returns one country given is alpha2 country code
+
+  ## Examples
+
+      iex> %Countries.Country{name: name} = Countries.get("PL")
+      iex> name
+      "Poland"
   """
 
   def get(country_code) do
@@ -21,11 +27,19 @@ defmodule Countries do
   Returns a list of `Countries.Country` structs
 
   ## Examples
-    iex> Countries.filter_by(:region, "Europe")
-    [%Countries.Country{address_format: nil, alpha2: "VA" ...
 
-    iex> Countries.filter_by(:names, "Reino Unido")
-    [%Countries.Country{address_format: nil, alpha2: "GB" ...
+      iex> countries = Countries.filter_by(:region, "Europe")
+      iex> Enum.count(countries)
+      51
+      iex> Enum.map(countries, &Map.get(&1, :alpha2)) |> Enum.take(5)
+      ["AD", "AL", "AT", "AX", "BA"] 
+
+      iex> countries = Countries.filter_by(:unofficial_names, "Reino Unido")
+      iex> Enum.count(countries)
+      1
+      iex> Enum.map(countries, &Map.get(&1, :name)) |> List.first
+      "United Kingdom of Great Britain and Northern Ireland"
+
   """
   def filter_by(attribute, value) do
     Enum.filter(countries(), fn country ->
@@ -48,11 +62,12 @@ defmodule Countries do
   Returns boolean
 
   ## Examples
-    iex> Countries.exists?(:name, "Poland")
-    true
 
-    iex> Countries.exists?(:name, "Polande")
-    false
+      iex> Countries.exists?(:name, "Poland")
+      true
+
+      iex> Countries.exists?(:name, "Polande")
+      false
   """
   def exists?(attribue, value) do
     filter_by(attribue, value) |> length > 0

--- a/test/countries_test.exs
+++ b/test/countries_test.exs
@@ -1,5 +1,6 @@
 defmodule CountriesTest do
   use ExUnit.Case, async: true
+  doctest Countries
 
   test "filter countries by alpha2" do
     country = Countries.filter_by(:alpha2, "DE")


### PR DESCRIPTION
Reformatted `Countries` doc strings so that:
1. Examples appear in proper code blocks
2. There is an example for `Countries.get/1`
3. Docs tests can be run.

Doc tests have also been enabled.