### PR TITLE
GB.yaml - Remove UK from EU and EEA membership

### DIFF
--- a/priv/data/countries/GB.yaml
+++ b/priv/data/countries/GB.yaml
@@ -27,8 +27,8 @@ GB:
   world_region: EMEA
   un_locode: GB
   nationality: British
-  eu_member: true
-  eea_member: true
+  eu_member: false
+  eea_member: false
   vat_rates:
     standard: 20
     reduced:


### PR DESCRIPTION
The UK is no longer a member of the EU or EEA. Updates GB.yaml accordingly.

This update was already made last February in the Ruby gem: https://github.com/hexorx/countries/commit/e418472e333479cce61a329d23eb22d900e28ddf#diff-fff374db57348190ba38704de9a8612e9187b36db73a1e09e84fc5e7376ef640