### PR TITLE
Update IN.yaml

### DIFF
--- a/priv/data/countries/IN.yaml
+++ b/priv/data/countries/IN.yaml
@@ -4,8 +4,8 @@ IN:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{region}}
-    {{city}} {{postalcode}}
+    {{locality}}
+    {{city}} {{postalcode}} {{region}}
     {{country}}
   alpha2: IN
   alpha3: IND


### PR DESCRIPTION
The locality is missing in the address format. It was mentioned as {{region}} but, that is a state and it goes after the {{zip code}} in the next line. Addresses in India have two lines, one for street and number, and other for locality / landmark / postoffice.