### PR TITLE
Correct the English translation of the Pomerania subdivision of Poland

### DIFF
--- a/priv/data/subdivisions/PL.yaml
+++ b/priv/data/subdivisions/PL.yaml
@@ -642,7 +642,7 @@ PM:
   - pomorskie
   - Pomorskie
   translations:
-    en: Federal Capital Territory
+    en: Pomerania
     af: Woiwodskap Pommere
     ar: محافظة بوميرانيا
     be: Паморскае ваяводства


### PR DESCRIPTION
I believe there's a mistake in the English translation of the Pomerania subdivision of Poland: https://en.wikipedia.org/wiki/Administrative_divisions_of_Poland#Voivodeships

