### PR TITLE
Fix lists conversion

### DIFF
--- a/lib/loader.ex
+++ b/lib/loader.ex
@@ -43,14 +43,15 @@ defmodule Countries.Loader do
     end)
   end
 
-  defp convert_value(:unofficial_names, names),
+  @convert ~w[unofficial_names languages_official languages_spoken]a
+  defp convert_value(attribute, names) when attribute in @convert,
     do: Enum.map(names, &to_string/1)
 
   defp convert_value(:geo, values),
     do: to_map(values)
 
   defp convert_value(attribute, value)
-       when is_list(value) and not (attribute in @do_not_convert),
+       when is_list(value) and attribute not in @do_not_convert,
        do: to_string(value)
 
   defp convert_value(_, value),

--- a/test/countries_test.exs
+++ b/test/countries_test.exs
@@ -66,7 +66,7 @@ defmodule CountriesTest do
 
     test "filters by official language" do
       countries = Countries.filter_by(:languages_official, "EN")
-      assert Enum.count(countries) == 48
+      assert Enum.count(countries) == 92
     end
 
     test "filters by integer attributes" do
@@ -87,5 +87,19 @@ defmodule CountriesTest do
 
     country = List.first(Countries.filter_by(:alpha2, "AI"))
     assert Enum.count(Countries.Subdivisions.all(country)) == 14
+  end
+
+  test "retain lists" do
+    country = Countries.get("CH")
+    assert is_list(country.languages_spoken)
+    assert "de" in country.languages_spoken
+    assert is_list(country.languages_official)
+    assert "de" in country.languages_official
+
+    assert "Switzerland" in (Countries.filter_by(:languages_official, "it")
+                             |> Enum.map(& &1.name))
+
+    assert "Switzerland" in (Countries.filter_by(:languages_spoken, "it")
+                             |> Enum.map(& &1.name))
   end
 end


### PR DESCRIPTION
The two lists `country.languages_official` and `country.languages_spoken` are now kept as lists.

This fixes the issue where currently:
```yaml
CH:
  continent: Europe
# …
  name: Switzerland
# …
  languages_official:
  - de
  - fr
  - it
  languages_spoken:
  - de
  - fr
  - it
```
```elixir
Countries.get("CH").languages_official == "defrit"
Countries.get("CH").languages_spoken == "defrit"
```

and makes it possible to filter countries by official languages and spoken languages.